### PR TITLE
修复端口为0或者空造成的中转问题

### DIFF
--- a/app/Controllers/Admin/RelayController.php
+++ b/app/Controllers/Admin/RelayController.php
@@ -46,6 +46,9 @@ class RelayController extends AdminController
         foreach ($dist_nodes as $node){
             if ($node->sort==11 or $node->sort==12){
                 $node_explode = explode(';', $node->server);
+                if ($node_explode[1]=="" || $node_explode[1]=="0"){
+                    $node_explode[1]="443";
+                }
                 $node->name = $node->name." 如果是V2ray后端 请设置成 ".$node_explode[1];
             }else {
                 $node->name = $node->name." 如果是V2ray后端 请不要设置，用户页面设置 ";
@@ -151,6 +154,9 @@ class RelayController extends AdminController
         foreach ($dist_nodes as $node){
             if ($node->sort==11 or $node->sort==12){
                 $node_explode = explode(';', $node->server);
+                if ($node_explode[1]=="" || $node_explode[1]=="0"){
+                    $node_explode[1]="443";
+                }
                 $node->name = $node->name." 如果是V2ray后端 请设置成".$node_explode[1];
             }else {
                 $node->name = $node->name." 如果是V2ray后端 请不要设置，用户页面设置 ";

--- a/app/Controllers/RelayController.php
+++ b/app/Controllers/RelayController.php
@@ -240,7 +240,7 @@ class RelayController extends UserController
                 $v2ray_port_raw="443";
             }
         }
-        if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port || $port!=$v2ray_port_raw))) {
+        if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port && $port!=$v2ray_port_raw))) {
             $rs['ret'] = 0;
             $rs['msg'] = "端口错误";
             return $response->getBody()->write(json_encode($rs));
@@ -418,7 +418,7 @@ class RelayController extends UserController
                 $v2ray_port_raw="443";
             }
         }
-        if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port || $port!=$v2ray_port_raw))) {
+        if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port && $port!=$v2ray_port_raw))) {
             $rs['ret'] = 0;
             $rs['msg'] = "端口错误";
             return $response->getBody()->write(json_encode($rs));

--- a/app/Controllers/RelayController.php
+++ b/app/Controllers/RelayController.php
@@ -155,6 +155,9 @@ class RelayController extends UserController
         foreach ($dist_nodes as $node){
             if ($node->sort==11 or $node->sort==12){
                 $node_explode = explode(';', $node->server);
+                if ($node_explode[1]=="" || $node_explode[1]=="0"){
+                    $node_explode[1]="443";
+                }
                 array_push($ports, $node_explode[1]);
                 $node->name = $node->name." 如果是V2ray后端 请设置成 ".$node_explode[1];
             }else {
@@ -233,6 +236,9 @@ class RelayController extends UserController
         if ($dist_node->sort ==12 || $dist_node->sort==11) {
             $node_explode = explode(';', $dist_node->server);
             $v2ray_port_raw= $node_explode[1];
+            if ($v2ray_port_raw=="" || $v2ray_port_raw=="0"){
+                $v2ray_port_raw="443";
+            }
         }
         if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port || $port!=$v2ray_port_raw))) {
             $rs['ret'] = 0;
@@ -331,6 +337,9 @@ class RelayController extends UserController
         foreach ($dist_nodes as $node){
             if ($node->sort==11 or $node->sort==12){
                 $node_explode = explode(';', $node->server);
+                if ($node_explode[1]=="" || $node_explode[1]=="0"){
+                    $node_explode[1]="443";
+                }
                 array_push($ports, $node_explode[1]);
                 $node->name = $node->name." 如果是V2ray后端 请设置成: ".$node_explode[1];
             }else {
@@ -405,6 +414,9 @@ class RelayController extends UserController
         if ($dist_node->sort ==12 || $dist_node->sort==11) {
             $node_explode = explode(';', $dist_node->server);
             $v2ray_port_raw= $node_explode[1];
+            if ($v2ray_port_raw=="" || $v2ray_port_raw=="0"){
+                $v2ray_port_raw="443";
+            }
         }
         if (($port_raw == null && $port != $user->port)||($v2ray_port_raw!="" && ($port!=$user->port || $port!=$v2ray_port_raw))) {
             $rs['ret'] = 0;


### PR DESCRIPTION
修复如果端口设置为0或者为空的情况下，(默认逻辑是监听443 的配置缺失的问题）